### PR TITLE
fix: Object missing __proto__

### DIFF
--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -352,7 +352,7 @@ export function JSONParse(options?: Options) {
     // Parse an object value.
 
     let key
-    const object = Object.create(null)
+    const object = new Object()
 
     if (ch === '{') {
       next('{')


### PR DESCRIPTION
if using `json_parse`
![image](https://github.com/HerringtonDarkholme/json-big/assets/46664126/29789426-dceb-4b18-9e99-bcf6753d897a)

actually expect
![image](https://github.com/HerringtonDarkholme/json-big/assets/46664126/3c424934-6646-4a8c-9219-691147f4d95c)
