### PR TITLE
Fix undefined property value

### DIFF
--- a/lib/stringify.ts
+++ b/lib/stringify.ts
@@ -186,7 +186,7 @@ function quote(string: string) {
     : `"${string}"`
 }
 
-function str(key: string|number, holder: Record<string|number, any>): string {
+function str(key: string|number, holder: Record<string|number, any>): string | undefined {
   // Produce a string from holder[key].
 
   let i // The loop counter.
@@ -311,8 +311,6 @@ function str(key: string|number, holder: Record<string|number, any>): string {
         : `{${partial.join(',')}}`
     gap = mind
     return v
-    default:
-      return 'null'
   }
 }
 


### PR DESCRIPTION
For object:

    {undefined: undefined}

Both `JSON.stringify` and JavaScript version `JSONBig.stringify` will result in `{}`. But this ts version library will result in `{"undefined": null}`

Related code line:

https://github.com/HerringtonDarkholme/json-big/blob/main/lib/stringify.ts#L314


